### PR TITLE
Jwebbinar dry run prep

### DIFF
--- a/deployments/jwebbinar/env-chilly/jwebbinar/requirements.txt
+++ b/deployments/jwebbinar/env-chilly/jwebbinar/requirements.txt
@@ -83,9 +83,9 @@ bleach~=6.0.0
     # via nbconvert
 bokeh~=3.2.2
     # via jupyter-bokeh
-boto3~=1.28.48
+boto3~=1.28.49
     # via -r /opt/common-env/common.pip
-botocore~=1.31.48
+botocore~=1.31.49
     # via
     #   boto3
     #   s3transfer
@@ -132,7 +132,7 @@ comm~=0.1.4
     # via
     #   ipykernel
     #   ipywidgets
-contourpy~=1.1.0
+contourpy~=1.1.1
     # via
     #   bokeh
     #   matplotlib
@@ -144,7 +144,7 @@ cryptography~=41.0.3
     #   secretstorage
 cycler~=0.11.0
     # via matplotlib
-dask[array]~=2023.9.1
+dask[array]~=2023.9.2
     # via
     #   casa-formats-io
     #   spectral-cube
@@ -194,7 +194,7 @@ frozenlist~=1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec~=2023.9.0
+fsspec~=2023.9.1
     # via dask
 glue-core~=1.13.1
     # via
@@ -485,7 +485,7 @@ nbsphinx~=0.9.3
     # via -r /opt/common-env/docs.pip
 nersc-refresh-announcements @ git+https://github.com/spacetelescope/nersc-refresh-announcements@octarine-updates
     # via -r /opt/common-env/jupyter.pip
-nest-asyncio~=1.5.7
+nest-asyncio~=1.5.8
     # via ipykernel
 networkx==3.1
     # via scikit-image
@@ -498,7 +498,7 @@ notebook-shim~=0.2.3
     # via
     #   jupyterlab
     #   notebook
-numpy~=1.25.2
+numpy~=1.26.0
     # via
     #   -r /opt/common-env/common.pip
     #   asdf
@@ -911,7 +911,7 @@ traittypes~=0.2.1
     #   bqplot
     #   ipydatawidgets
     #   ipyvolume
-typing-extensions~=4.7.1
+typing-extensions~=4.8.0
     # via
     #   alembic
     #   sqlalchemy
@@ -956,7 +956,7 @@ yarl~=1.9.2
     # via aiohttp
 ypy-websocket~=0.12.3
     # via -r /opt/common-env/jupyter.pip
-zipp~=3.16.2
+zipp~=3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/deployments/jwebbinar/env-chilly/jwebbinar/requirements.yml
+++ b/deployments/jwebbinar/env-chilly/jwebbinar/requirements.yml
@@ -36,7 +36,7 @@ dependencies:
   - click~=8.1.7
   - colorama~=0.4.6
   - comm~=0.1.4
-  - contourpy~=1.1.0
+  - contourpy~=1.1.1
   - cryptography~=41.0.3
   - cycler~=0.11.0
   - dbus~=1.13.6
@@ -120,7 +120,7 @@ dependencies:
   - libclang~=15.0.7
   - libclang13~=15.0.7
   - libcups~=2.3.3
-  - libdeflate=1.18
+  - libdeflate=1.19
   - libedit~=3.1.20191231
   - libevent~=2.1.12
   - libexpat~=2.5.0
@@ -181,7 +181,7 @@ dependencies:
   - notebook-shim~=0.2.3
   - nspr=4.35
   - nss=3.92
-  - numpy~=1.25.2
+  - numpy~=1.26.0
   - openblas~=0.3.24
   - openjpeg~=2.5.0
   - openssl~=3.1.2
@@ -193,7 +193,7 @@ dependencies:
   - pcre2=10.40
   - pexpect~=4.8.0
   - pickleshare~=0.7.5
-  - pillow~=10.0.0
+  - pillow~=10.0.1
   - pip~=23.2.1
   - pip-tools~=7.3.0
   - pixman~=0.40.0
@@ -254,8 +254,8 @@ dependencies:
   - tomlkit~=0.12.1
   - tornado~=6.3.3
   - traitlets~=5.10.0
-  - typing-extensions~=4.7.1
-  - typing_extensions~=4.7.1
+  - typing-extensions~=4.8.0
+  - typing_extensions~=4.8.0
   - typing_utils~=0.1.0
   - tzdata=2023c
   - unixodbc~=2.3.12

--- a/deployments/jwebbinar/env-frozen/base/requirements.yml
+++ b/deployments/jwebbinar/env-frozen/base/requirements.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=4.5
-  - alembic=1.11.3
+  - alembic=1.12.0
   - altair=5.1.1
   - anyio=4.0.0
   - aom=3.5.0
@@ -61,34 +61,34 @@ dependencies:
   - cloudpickle=2.2.1
   - colorama=0.4.6
   - comm=0.1.4
-  - conda=23.7.3
+  - conda=23.7.4
   - conda-package-handling=2.2.0
   - conda-package-streaming=0.9.0
   - configurable-http-proxy=4.5.6
-  - contourpy=1.1.0
+  - contourpy=1.1.1
   - cryptography=41.0.3
   - cycler=0.11.0
   - cython=3.0.2
   - cytoolz=0.12.2
-  - dask=2023.9.1
-  - dask-core=2023.9.1
+  - dask=2023.9.2
+  - dask-core=2023.9.2
   - dav1d=1.2.1
-  - debugpy=1.7.0
+  - debugpy=1.8.0
   - decorator=5.1.1
   - defusedxml=0.7.1
   - deprecated=1.2.14
   - deprecation=2.1.0
   - dill=0.3.7
-  - distributed=2023.9.1
+  - distributed=2023.9.2
   - entrypoints=0.4
   - et_xmlfile=1.1.0
   - exceptiongroup=1.1.3
   - executing=1.2.0
-  - fmt=9.1.0
+  - fmt=10.1.1
   - fonttools=4.42.1
   - fqdn=1.5.1
   - freetype=2.12.1
-  - fsspec=2023.9.0
+  - fsspec=2023.9.1
   - gflags=2.2.2
   - giflib=5.2.1
   - gitdb=4.0.10
@@ -117,7 +117,7 @@ dependencies:
   - joblib=1.3.2
   - json5=0.9.14
   - jsonpatch=1.32
-  - jsonpointer=2.0
+  - jsonpointer=2.4
   - jsonschema=4.19.0
   - jsonschema-specifications=2023.7.1
   - jsonschema-with-format-nongpl=4.19.0
@@ -132,10 +132,10 @@ dependencies:
   - jupyter_telemetry=0.1.0
   - jupyterhub=4.0.2
   - jupyterhub-base=4.0.2
-  - jupyterlab=4.0.5
+  - jupyterlab=4.0.6
   - jupyterlab-git=0.41.0
   - jupyterlab_pygments=0.2.2
-  - jupyterlab_server=2.24.0
+  - jupyterlab_server=2.25.0
   - jupyterlab_widgets=3.0.9
   - jwcrypto=1.5.0
   - jxrlib=1.1
@@ -157,17 +157,17 @@ dependencies:
   - libbrotlienc=1.1.0
   - libcblas=3.9.0
   - libcrc32c=1.1.2
-  - libcurl=8.2.1
-  - libdeflate=1.18
+  - libcurl=8.3.0
+  - libdeflate=1.19
   - libedit=3.1.20191231
   - libev=4.33
   - libevent=2.1.12
   - libexpat=2.5.0
   - libffi=3.4.2
-  - libgcc-ng=13.1.0
+  - libgcc-ng=13.2.0
   - libgfortran-ng=13.2.0
   - libgfortran5=13.2.0
-  - libgomp=13.1.0
+  - libgomp=13.2.0
   - libgoogle-cloud=2.12.0
   - libgrpc=1.57.0
   - libiconv=1.17
@@ -175,8 +175,8 @@ dependencies:
   - liblapack=3.9.0
   - liblapacke=3.9.0
   - libllvm14=14.0.6
-  - libmamba=1.5.0
-  - libmambapy=1.5.0
+  - libmamba=1.5.1
+  - libmambapy=1.5.1
   - libnghttp2=1.52.0
   - libnsl=2.0.0
   - libnuma=2.0.16
@@ -187,9 +187,9 @@ dependencies:
   - libsolv=0.7.24
   - libsqlite=3.43.0
   - libssh2=1.11.0
-  - libstdcxx-ng=13.1.0
+  - libstdcxx-ng=13.2.0
   - libthrift=0.19.0
-  - libtiff=4.5.1
+  - libtiff=4.6.0
   - libutf8proc=2.8.0
   - libuuid=2.38.1
   - libuv=1.46.0
@@ -205,7 +205,7 @@ dependencies:
   - lz4-c=1.9.4
   - lzo=2.10
   - mako=1.2.4
-  - mamba=1.5.0
+  - mamba=1.5.1
   - markupsafe=2.1.3
   - matplotlib-base=3.7.2
   - matplotlib-inline=0.1.6
@@ -249,7 +249,7 @@ dependencies:
   - patsy=0.5.3
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pillow=10.0.0
+  - pillow=10.0.1
   - pip=23.2.1
   - pip-tools=7.3.0
   - pkgutil-resolve-name=1.3.10
@@ -298,7 +298,7 @@ dependencies:
   - requests=2.31.0
   - rfc3339-validator=0.1.4
   - rfc3986-validator=0.1.1
-  - rpds-py=0.10.2
+  - rpds-py=0.10.3
   - ruamel.yaml=0.17.32
   - ruamel.yaml.clib=0.2.7
   - s2n=1.3.51
@@ -332,9 +332,9 @@ dependencies:
   - toolz=0.12.0
   - tornado=6.3.3
   - tqdm=4.66.1
-  - traitlets=5.9.0
-  - typing-extensions=4.7.1
-  - typing_extensions=4.7.1
+  - traitlets=5.10.0
+  - typing-extensions=4.8.0
+  - typing_extensions=4.8.0
   - typing_utils=0.1.0
   - tzdata=2023c
   - ucx=1.14.1
@@ -360,7 +360,7 @@ dependencies:
   - zipp=3.16.2
   - zlib=1.2.13
   - zlib-ng=2.0.7
-  - zstandard=0.19.0
+  - zstandard=0.21.0
   - zstd=1.5.5
   - pip:
       - aiohttp==3.8.5
@@ -375,8 +375,8 @@ dependencies:
       - astropy==5.3.3
       - astropy-sphinx-theme==1.1
       - black==23.9.1
-      - boto3==1.28.48
-      - botocore==1.31.48
+      - boto3==1.28.49
+      - botocore==1.31.49
       - bqplot==0.12.40
       - bqplot-gl==0.0.0
       - bqplot-image-gl==1.4.11

--- a/deployments/jwebbinar/env-frozen/jwebbinar/requirements.txt
+++ b/deployments/jwebbinar/env-frozen/jwebbinar/requirements.txt
@@ -83,9 +83,9 @@ bleach==6.0.0
     # via nbconvert
 bokeh==3.2.2
     # via jupyter-bokeh
-boto3==1.28.48
+boto3==1.28.49
     # via -r /opt/common-env/common.pip
-botocore==1.31.48
+botocore==1.31.49
     # via
     #   boto3
     #   s3transfer
@@ -132,7 +132,7 @@ comm==0.1.4
     # via
     #   ipykernel
     #   ipywidgets
-contourpy==1.1.0
+contourpy==1.1.1
     # via
     #   bokeh
     #   matplotlib
@@ -144,7 +144,7 @@ cryptography==41.0.3
     #   secretstorage
 cycler==0.11.0
     # via matplotlib
-dask[array]==2023.9.1
+dask[array]==2023.9.2
     # via
     #   casa-formats-io
     #   spectral-cube
@@ -194,7 +194,7 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2023.9.0
+fsspec==2023.9.1
     # via dask
 glue-core==1.13.1
     # via
@@ -485,7 +485,7 @@ nbsphinx==0.9.3
     # via -r /opt/common-env/docs.pip
 nersc-refresh-announcements @ git+https://github.com/spacetelescope/nersc-refresh-announcements@octarine-updates
     # via -r /opt/common-env/jupyter.pip
-nest-asyncio==1.5.7
+nest-asyncio==1.5.8
     # via ipykernel
 networkx==3.1
     # via scikit-image
@@ -498,7 +498,7 @@ notebook-shim==0.2.3
     # via
     #   jupyterlab
     #   notebook
-numpy==1.25.2
+numpy==1.26.0
     # via
     #   -r /opt/common-env/common.pip
     #   asdf
@@ -911,7 +911,7 @@ traittypes==0.2.1
     #   bqplot
     #   ipydatawidgets
     #   ipyvolume
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   alembic
     #   sqlalchemy
@@ -956,7 +956,7 @@ yarl==1.9.2
     # via aiohttp
 ypy-websocket==0.12.3
     # via -r /opt/common-env/jupyter.pip
-zipp==3.16.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/deployments/jwebbinar/env-frozen/jwebbinar/requirements.yml
+++ b/deployments/jwebbinar/env-frozen/jwebbinar/requirements.yml
@@ -36,7 +36,7 @@ dependencies:
   - click=8.1.7
   - colorama=0.4.6
   - comm=0.1.4
-  - contourpy=1.1.0
+  - contourpy=1.1.1
   - cryptography=41.0.3
   - cycler=0.11.0
   - dbus=1.13.6
@@ -120,7 +120,7 @@ dependencies:
   - libclang=15.0.7
   - libclang13=15.0.7
   - libcups=2.3.3
-  - libdeflate=1.18
+  - libdeflate=1.19
   - libedit=3.1.20191231
   - libevent=2.1.12
   - libexpat=2.5.0
@@ -181,7 +181,7 @@ dependencies:
   - notebook-shim=0.2.3
   - nspr=4.35
   - nss=3.92
-  - numpy=1.25.2
+  - numpy=1.26.0
   - openblas=0.3.24
   - openjpeg=2.5.0
   - openssl=3.1.2
@@ -193,7 +193,7 @@ dependencies:
   - pcre2=10.40
   - pexpect=4.8.0
   - pickleshare=0.7.5
-  - pillow=10.0.0
+  - pillow=10.0.1
   - pip=23.2.1
   - pip-tools=7.3.0
   - pixman=0.40.0
@@ -254,8 +254,8 @@ dependencies:
   - tomlkit=0.12.1
   - tornado=6.3.3
   - traitlets=5.10.0
-  - typing-extensions=4.7.1
-  - typing_extensions=4.7.1
+  - typing-extensions=4.8.0
+  - typing_extensions=4.8.0
   - typing_utils=0.1.0
   - tzdata=2023c
   - unixodbc=2.3.12

--- a/deployments/jwebbinar/environments/post-start-hook
+++ b/deployments/jwebbinar/environments/post-start-hook
@@ -14,7 +14,7 @@ HUB_FLAG=${1:-"on-hub"}
 
 TIMESTAMP=`date +%Y-%m-%d.%H%M%S`
 mkdir -p ~/archive/$TIMESTAMP/
-mv ~/jwebb_prep/ ~/archive/$TIMESTAMP/ || true
+mv ~/jwebbinar_prep/ ~/archive/$TIMESTAMP/ || true
 
 git clone -b current_webbinar https://github.com/spacetelescope/jwebbinar_prep
 /opt/common-scripts/set-notebook-kernel jwebbinar jwebbinar_prep/**/**/*.ipynb || true

--- a/deployments/jwebbinar/environments/post-start-hook
+++ b/deployments/jwebbinar/environments/post-start-hook
@@ -12,8 +12,12 @@ HUB_FLAG=${1:-"on-hub"}
 
 /opt/common-scripts/copy-default-home
 
-/opt/environments/setup-notebooks
+TIMESTAMP=`date +%Y-%m-%d.%H%M%S`
+mkdir -p ~/archive/$TIMESTAMP/
+mv ~/jwebb_prep/ ~/archive/$TIMESTAMP/ || true
 
+git clone -b current_webbinar https://github.com/spacetelescope/jwebbinar_prep
+/opt/common-scripts/set-notebook-kernel jwebbinar jwebbinar_prep/**/**/*.ipynb || true
 
 if [[ $HUB_FLAG == "on-hub" ]]; then
     /opt/common-scripts/symlink-crds
@@ -22,5 +26,3 @@ fi
 # Remove VNC Desktop from Launcher
 rm -rf /home/jovyan/.user-dirs/Desktop
 rm -rf /home/jovyan/Desktop
-
-# ha


### PR DESCRIPTION
As-built changes to jwebbinar-dev for jwebbinar-25,  particularly switch to provided .yml conda spec and minimization of notebook setup and git-sync'ing due to issues with both old and new git-sync.