### PR TITLE
Moved stsci-announce install to spacetelescope repo

### DIFF
--- a/deployments/common/common-env/jupyter.pip
+++ b/deployments/common/common-env/jupyter.pip
@@ -24,7 +24,7 @@ ipyvuetify
 ipywebrtc
 ipykernel
 jupyter-resource-usage
-git+https://github.com/spacetelescope/nersc-refresh-announcements@octarine-updates
+git+https://github.com/spacetelescope/stsci-announce
 sidecar
 y-py
 ypy-websocket


### PR DESCRIPTION
As part of rebranding the announcements labextension,  the repo was renamed to stsci-announce.