### PR TITLE
Fix-permissions in CONDA_DIR and HOME

### DIFF
--- a/deployments/common/Dockerfile.trailer
+++ b/deployments/common/Dockerfile.trailer
@@ -56,6 +56,17 @@ RUN echo "# -------------------------------- STSCI Config Overwrites -----------
     echo "c.FileContentsManager.delete_to_trash = False" >> /etc/jupyter/jupyter_server_config.py &&\
     echo "c.FileContentsManager.always_delete_dir = True" >> /etc/jupyter/jupyter_server_config.py
 
+# For testing mutability of pre-installed environments once uidgid's are real, membership in users controls
+# mutability but fix-permissions must be called on files which need to be mutable, particularly those we install.
+#
+## USER root
+## RUN echo "jmiller:x:1001:1001::/home/jovyan:/bin/bash" >>/etc/passwd
+## RUN grep -v users /etc/group >tmp
+## RUN mv tmp /etc/group
+## RUN echo "users:x:100:jmiller" >>/etc/group
+## RUN echo "jmiller:x:1001:jmiller" >>/etc/group
+## USER $NB_USER
+
 USER $NB_USER
 WORKDIR /home/$NB_USER
 RUN /opt/environments/post-start-hook  docker   # docker == do not run hub-specific functions of hook

--- a/deployments/common/common-scripts/env-compile
+++ b/deployments/common/common-scripts/env-compile
@@ -92,3 +92,4 @@ pip-compile  -v  --resolver=backtracking --output-file ${env_reqs} --pip-args "$
 
 /opt/common-scripts/env-clean
 
+fix-permissions $CONDA_DIR $HOME

--- a/deployments/common/common-scripts/env-conda
+++ b/deployments/common/common-scripts/env-conda
@@ -65,6 +65,6 @@ ${CONDA_VER} env export --no-build -n ${env} > ${env_frozen_yml}
 # echo "===== Creating conda environment ${env} from frozen constraints ${env_frozen_yml}"
 # env_create ${env_frozen_yml}
 
-env-clean
+/opt/common-scripts/env-clean
 
 fix-permissions $CONDA_DIR $HOME

--- a/deployments/common/common-scripts/env-conda
+++ b/deployments/common/common-scripts/env-conda
@@ -64,3 +64,7 @@ ${CONDA_VER} env export --no-build -n ${env} > ${env_frozen_yml}
 # ${CONDA_VER} env remove -n ${env}
 # echo "===== Creating conda environment ${env} from frozen constraints ${env_frozen_yml}"
 # env_create ${env_frozen_yml}
+
+env-clean
+
+fix-permissions $CONDA_DIR $HOME

--- a/deployments/common/common-scripts/env-src-install
+++ b/deployments/common/common-scripts/env-src-install
@@ -32,3 +32,5 @@ source /opt/common-scripts/env-activate $ENV
 pip install --verbose --no-deps --no-cache --no-binary ${PKG} --force-reinstall --no-build-isolation ${PKG}
 
 /opt/common-scripts/env-clean
+
+fix-permissions $CONDA_DIR $HOME

--- a/deployments/common/common-scripts/env-sync
+++ b/deployments/common/common-scripts/env-sync
@@ -28,3 +28,6 @@ echo "===== Installing required pip packages for environment ${env}..."
 pip-sync --verbose --pip-args "${PIP_SWITCHES}" --python-executable `which python`   /opt/env-frozen/${env}/requirements.txt
 
 /opt/common-scripts/env-clean
+
+fix-permissions $CONDA_DIR $HOME
+

--- a/deployments/common/common-scripts/install-common
+++ b/deployments/common/common-scripts/install-common
@@ -21,3 +21,8 @@ ${CONDA_VER} env export --no-build -n base >/opt/env-frozen/base/requirements.ym
 if pip freeze | grep jupyter-server-proxy; then
     jupyter labextension install @jupyterlab/server-proxy
 fi
+
+
+env-clean
+
+fix-permissions $CONDA_DIR $HOME

--- a/deployments/common/common-scripts/install-common
+++ b/deployments/common/common-scripts/install-common
@@ -23,6 +23,6 @@ if pip freeze | grep jupyter-server-proxy; then
 fi
 
 
-env-clean
+/opt/common-scripts/env-clean
 
 fix-permissions $CONDA_DIR $HOME

--- a/deployments/jwebbinar/Dockerfile
+++ b/deployments/jwebbinar/Dockerfile
@@ -134,6 +134,17 @@ RUN echo "# -------------------------------- STSCI Config Overwrites -----------
     echo "c.FileContentsManager.delete_to_trash = False" >> /etc/jupyter/jupyter_server_config.py &&\
     echo "c.FileContentsManager.always_delete_dir = True" >> /etc/jupyter/jupyter_server_config.py
 
+# For testing mutability of pre-installed environments once uidgid's are real, membership in users controls
+# mutability but fix-permissions must be called on files which need to be mutable, particularly those we install.
+#
+## USER root
+## RUN echo "jmiller:x:1001:1001::/home/jovyan:/bin/bash" >>/etc/passwd
+## RUN grep -v users /etc/group >tmp
+## RUN mv tmp /etc/group
+## RUN echo "users:x:100:jmiller" >>/etc/group
+## RUN echo "jmiller:x:1001:jmiller" >>/etc/group
+## USER $NB_USER
+
 USER $NB_USER
 WORKDIR /home/$NB_USER
 RUN /opt/environments/post-start-hook  docker   # docker == do not run hub-specific functions of hook

--- a/deployments/roman/Dockerfile
+++ b/deployments/roman/Dockerfile
@@ -127,6 +127,17 @@ RUN echo "# -------------------------------- STSCI Config Overwrites -----------
     echo "c.FileContentsManager.delete_to_trash = False" >> /etc/jupyter/jupyter_server_config.py &&\
     echo "c.FileContentsManager.always_delete_dir = True" >> /etc/jupyter/jupyter_server_config.py
 
+# For testing mutability of pre-installed environments once uidgid's are real, membership in users controls
+# mutability but fix-permissions must be called on files which need to be mutable, particularly those we install.
+#
+## USER root
+## RUN echo "jmiller:x:1001:1001::/home/jovyan:/bin/bash" >>/etc/passwd
+## RUN grep -v users /etc/group >tmp
+## RUN mv tmp /etc/group
+## RUN echo "users:x:100:jmiller" >>/etc/group
+## RUN echo "jmiller:x:1001:jmiller" >>/etc/group
+## USER $NB_USER
+
 USER $NB_USER
 WORKDIR /home/$NB_USER
 RUN /opt/environments/post-start-hook  docker   # docker == do not run hub-specific functions of hook

--- a/deployments/tike/Dockerfile
+++ b/deployments/tike/Dockerfile
@@ -85,8 +85,6 @@ COPY --chown=${NB_UID}:${NB_GID} environments/tess/ /opt/environments/tess/
 # YYYY SEC
 
 USER $NB_USER
-RUN  /opt/common-scripts/npm-audit  /opt/conda/envs/tess/lib/python3.8/site-packages/panel  fix  && \
-     /opt/common-scripts/env-clean
 
 # Suppress tensorflow warnings by default, ERROR and up only
 ENV TF_CPP_MIN_LOG_LEVEL=2
@@ -149,6 +147,17 @@ RUN echo "# -------------------------------- STSCI Config Overwrites -----------
       >> /etc/jupyter/jupyter_server_config.py &&\
     echo "c.FileContentsManager.delete_to_trash = False" >> /etc/jupyter/jupyter_server_config.py &&\
     echo "c.FileContentsManager.always_delete_dir = True" >> /etc/jupyter/jupyter_server_config.py
+
+# For testing mutability of pre-installed environments once uidgid's are real, membership in users controls
+# mutability but fix-permissions must be called on files which need to be mutable, particularly those we install.
+#
+## USER root
+## RUN echo "jmiller:x:1001:1001::/home/jovyan:/bin/bash" >>/etc/passwd
+## RUN grep -v users /etc/group >tmp
+## RUN mv tmp /etc/group
+## RUN echo "users:x:100:jmiller" >>/etc/group
+## RUN echo "jmiller:x:1001:jmiller" >>/etc/group
+## USER $NB_USER
 
 USER $NB_USER
 WORKDIR /home/$NB_USER


### PR DESCRIPTION
docker-stacks adheres to a convention whereby files in the system it wants to be mutable by users are chmod'ed by the script to be owned by jovyan:users where users has write permissions.   This enables the installation of new s/w and removal of existing s/w.

AC: modify the framework installation scripts to fix-permissions on CONDA_DIR and HOME after each installation,  ensuring that permissions are modified within the same layer a file or directory is first created.  If the fix-permissions does not occur in the same layer,  it results in large amounts of bloat as it installs new copies of files vs. changing metadata in place.

