### PR TITLE
Pr build against branch

### DIFF
--- a/.github/workflows/build-frozen.yml
+++ b/.github/workflows/build-frozen.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          ref: main
+          fetch-depth: 0
 
       - name: Free Disk Space,  Enlarge Swapfile
         shell: bash
@@ -54,6 +54,7 @@ jobs:
       - name: Image Build
         shell: bash
         run: |
+           echo "Running on branch ${{ github.head_ref }}"
            source setup-env
            scripts/image-build
            df -h
@@ -65,6 +66,7 @@ jobs:
       - name: Image Functional Tests
         shell: bash
         run: |
+           echo "Running on branch ${{ github.head_ref }}"
            df -h
            source setup-env
            scripts/image-test
@@ -73,6 +75,7 @@ jobs:
       - name: Git Diffs (Frozen Specs)
         shell: bash
         run: |
+           echo "Running on branch ${{ github.head_ref }}"
            git diff || true
 
       - name: Clear setup-env


### PR DESCRIPTION
Makes the current "frozen" build which is triggered by a PR build the branch that was PR'ed vs. main.
Ideally we want to know that the branch-merged-to-main works so potentially we should switch to that by merging main in the local clone prior to building.   For now,  at least this builds something related to the PR'ed  branch vs. existing main.