### PR TITLE
cache-clear exception reporting bug

### DIFF
--- a/deployments/common/tools/cache-clear
+++ b/deployments/common/tools/cache-clear
@@ -35,14 +35,14 @@ def clear_cache():
         print(f"Clearing astropy cache {ap_cache}.")
         astropy.utils.data.clear_download_cache()
     except Exception:
-        print(f"Failed clearing astropy cache at {ap_cache}.")
+        pass
     try:
         import lightkurve.config
         lk_cache = lightkurve.config.get_cache_dir()
         print(f"Clearing lightkurve cache {lk_cache}.")
         rm_files(lk_cache)
     except Exception:
-        print(f"Failed clearing lightkurve cache at {lk_cache}.")
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reduced cache-clear error reporting because it was buggy and inappropriate for multi-mission use and reporting failures on non-existent caches.  Cache-clear was originally written to be run automatically for TIKE during logouts and since lightkurve is not installed for Roman reporting anything about clearing its cache is not useful for Roman.   These commands are documented in the MAST user's guide so a fix is needed.

