### PR TITLE
Build framework tweaks for conda/mamba and Ubuntu

### DIFF
--- a/deployments/common/Dockerfile
+++ b/deployments/common/Dockerfile
@@ -29,7 +29,7 @@ ARG PIP_SWITCHES=""
 ENV PIP_SWITCHES=$PIP_SWITCHES
 
 # Enable easy swap of conda with e.g. mamba
-ARG CONDA_VER=mamba
+ARG CONDA_VER=conda
 ENV CONDA_VER=${CONDA_VER}
 
 ARG USER_CACHE_DIRS=""
@@ -87,7 +87,7 @@ RUN /opt/common-scripts/apt-install \
         cmake \
         vim \
         emacs-nox \
-        fftw3-dev \
+        libfftw3-dev \
         libatlas-base-dev \
         libcurl4-openssl-dev \
         libxml2 \
@@ -96,7 +96,6 @@ RUN /opt/common-scripts/apt-install \
         libxslt1-dev \
         python3-libxml2 \
         python-dev-is-python3 \
-        python-setuptools \
         graphviz \
         libopenblas-dev
 

--- a/deployments/tike/environments/common-hints.pip
+++ b/deployments/tike/environments/common-hints.pip
@@ -9,3 +9,5 @@
 # ---- jupyter-server==1.23.5
 # ---- y-py==0.5.4
 # ---- ypy-websocket==0.8.2
+
+papermill>=2.6.0

--- a/infrequent-env
+++ b/infrequent-env
@@ -16,14 +16,11 @@ export CONDA_VER=conda  # switch to conda while "mamba env export" in install-co
 # Additional parameters for image-exec Docker run command, e.g. add mounts here
 export IMAGE_RUN_PARS="--rm -e JUPYTER_ENABLE_LAB=yes --platform ${PLATFORM}"
 
-# Image scanning,  report Ubuntu status for this version of Ubuntu
-export UBUNTU_TAG="20.04"
-
 # Image scanning,  report CVE's at this severity level and  higher
 export IMAGE_VULNERABILITY_LEVEL="medium"
 
 # Extra standard parameters to docker build commands
-export DOCKER_BUILD_ARGS="--rm --force-rm  --build-arg OWNER=${OWNER} --build-arg REGISTRY=${REGISTRY}  --progress plain --platform ${PLATFORM}"
+export DOCKER_BUILD_ARGS="--rm --force-rm  --build-arg OWNER=${OWNER} --build-arg REGISTRY=${REGISTRY}  --progress plain --platform ${PLATFORM} --build-arg ${CONDA_VER}"
 
 export ROOT_CONTAINER=ubuntu:${UBUNTU_TAG}
 

--- a/infrequent-env
+++ b/infrequent-env
@@ -22,7 +22,7 @@ export IMAGE_VULNERABILITY_LEVEL="medium"
 # Extra standard parameters to docker build commands
 export DOCKER_BUILD_ARGS="--rm --force-rm  --build-arg OWNER=${OWNER} --build-arg REGISTRY=${REGISTRY}  --progress plain --platform ${PLATFORM} --build-arg ${CONDA_VER}"
 
-export ROOT_CONTAINER=ubuntu:${UBUNTU_TAG}
+export ROOT_IMAGE=ubuntu:${UBUNTU_TAG}
 
 # -------------------------------------------------------------------
 # Docker Buildkit has two killer features:

--- a/scripts/image-base
+++ b/scripts/image-base
@@ -51,7 +51,7 @@ build_jh() {
 }
 
 
-build_jh  docker-stacks-foundation  --build-arg ROOT_CONTAINER=${ROOT_CONTAINER}
+build_jh  docker-stacks-foundation  --build-arg ROOT_IMAGE=${ROOT_IMAGE}
 
 build_jh  base-notebook     --build-arg BASE_IMAGE=${OWNER}/docker-stacks-foundation:latest
 

--- a/scripts/image-base
+++ b/scripts/image-base
@@ -50,15 +50,11 @@ build_jh() {
            $*
 }
 
-sed -i '' -e "s/latest/1.5.10/g" ./images/docker-stacks-foundation/Dockerfile
-sed -i '' -e "s/'mamba' /'mamba==1.5.10' /g" ./images/docker-stacks-foundation/Dockerfile
-
-echo $(cat ./images/docker-stacks-foundation/Dockerfile)
 
 build_jh  docker-stacks-foundation  --build-arg ROOT_CONTAINER=${ROOT_CONTAINER}
 
-build_jh  base-notebook     --build-arg BASE_CONTAINER=${OWNER}/docker-stacks-foundation:latest
+build_jh  base-notebook     --build-arg BASE_IMAGE=${OWNER}/docker-stacks-foundation:latest
 
-build_jh  minimal-notebook  --build-arg BASE_CONTAINER=${OWNER}/base-notebook:latest
+build_jh  minimal-notebook  --build-arg BASE_IMAGE=${OWNER}/base-notebook:latest
 
-build_jh  scipy-notebook    --build-arg BASE_CONTAINER=${OWNER}/minimal-notebook:latest
+build_jh  scipy-notebook    --build-arg BASE_IMAGE=${OWNER}/minimal-notebook:latest

--- a/scripts/image-configure
+++ b/scripts/image-configure
@@ -43,7 +43,7 @@ def create_setup_env_file(
         if owner == "spacetelescope":
             content = re.sub(r"REGISTRY=.+", 'REGISTRY=""', content)
         else:
-            content = re.sub(r"REGISTRY=.+", f'REGISTRY="{owner}"', content)
+            content = re.sub(r"REGISTRY=.+", f'REGISTRY="{owner}/"', content)
 
     with open("setup-env", "w+") as file:
         file.write(content)

--- a/setup-env
+++ b/setup-env
@@ -6,31 +6,37 @@
 
 # ----------------- basic inputs,  must set for deployment --------------
 
-export DEPLOYMENT_NAME=jwebbinar
+export DEPLOYMENT_NAME=tike
 export ENVIRONMENT=sandbox
 export CAL_VERSION=none
 
 export USE_FROZEN=0                  # use 0 for loosely pinned package versions,
-                                     # 1 for tagged production build
+                                     # 1 for tagged/frozen production build
 
-export FREEZE=1                      # capture new frozen requirements as
-                                     # modified files in this git repo
+export FREEZE=1                     # dump new frozen requirements in image to modified files in this git repo
 
 export PLATFORM=linux/amd64
 
-export REGISTRY=""                         # empty for DockerHub
-# export REGISTRY="quay.io/repository/"    # but jupyter/docker-stacks is now at quay.io/repository
+
+
+# Set to "" (empty) for source build,  or quay.io/jupyter/ for current docker-stacks image.
+# jupyter is now at quay.io/jupyter/  needed to obtain fresh builds.  trailing backslash required
+export REGISTRY=""
+# export REGISTRY=""
 
 
 
+# OWNER=spacetelescope
+# quay.io/jupyter has the official pre-built images,  no trailing backslash
 export OWNER=spacetelescope
-                                     # jupyter or spacetelescope base image repo
-                                     # jupyter will be pulled from DockerHub, stale, but quay.io TBD
+# export OWNER=spacetelescope
 
-export BASE_IMAGE=${OWNER}/scipy-notebook   # from jupyter/docker-stacks
+export BASE_IMAGE=${OWNER}/scipy-notebook   # see above
 
 export NOTEBOOK_TAG=latest
 export NOTEBOOK_ID=notebook-${DEPLOYMENT_NAME}:${NOTEBOOK_TAG}  # abstract name of mission-specific notebook image
+
+export UBUNTU_TAG="24.04"	     # # Image scanning,  report Ubuntu status for this version of Ubuntu
 
 # ----------------- vvvv less frequently changed vvvv -------------------------------
 

--- a/setup-env.template
+++ b/setup-env.template
@@ -15,20 +15,28 @@ export USE_FROZEN=0                  # use 0 for loosely pinned package versions
 
 export FREEZE=1                     # dump new frozen requirements in image to modified files in this git repo
 
-export PLATFORM="linux/amd64"        # os / instruction-set for built image: linux/amd64 or linux/aarch64
-
-export REGISTRY=""                      # empty for DockerHub or source build,  quay.io/jupyter for current docker-stacks image.
-# export REGISTRY="quay.io/jupyter/"    # but jupyter is now at quay.io/jupyter
+export PLATFORM="linux/amd64"       # os / instruction-set for built image: linux/amd64 or linux/aarch64
 
 
 
-export OWNER="spacetelescope"        # spacetelescope will be built from source code
-                                     # quay.io/jupyter image or spacetelescope for github/jupyter/docker-stacks code
+# Set to "" (empty) for source build,  or quay.io/jupyter/ for current docker-stacks image.
+# jupyter is now at quay.io/jupyter/  needed to obtain fresh builds.  trailing backslash required
+export REGISTRY=""
+# export REGISTRY="quay.io/jupyter/" 
+
+
+
+# OWNER=spacetelescope will be built from docker-stacks source code
+# quay.io/jupyter has the official pre-built images,  no trailing backslash
+export OWNER="spacetelescope"
+# export OWNER="quay.io/jupyter"
 
 export BASE_IMAGE=${OWNER}/scipy-notebook   # see above
 
 export NOTEBOOK_TAG=latest
 export NOTEBOOK_ID=notebook-${DEPLOYMENT_NAME}:${NOTEBOOK_TAG}  # abstract name of mission-specific notebook image
+
+export UBUNTU_TAG="24.04"	     # # Image scanning,  report Ubuntu status for this version of Ubuntu
 
 # ----------------- vvvv less frequently changed vvvv -------------------------------
 


### PR DESCRIPTION
- Rolls back temporary JWST masterclass build framework work-arounds
- Switched back from mamba to conda.
- Updated to Ubuntu 24.04.
- Fixed bug in docker stacks image chaining.
- Tweaked image configuration setup-env.template and image-configure. Pinned papermill for TIKE using common-- hints.pip to get a build.