### PR TITLE
Work on release tagging scripts,  freezing

### DIFF
--- a/deployments/common/Dockerfile.trailer
+++ b/deployments/common/Dockerfile.trailer
@@ -29,6 +29,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/    /opt/environments/
 
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_VERSION /opt
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_HASH /opt
+RUN  [ $USE_FROZEN -eq "1" ] && echo >/opt/FROZEN || echo >/opt/FLOATING
 
 # ----------------------------------------------------------------------
 # For standalone operation outside JupyterHub,  note that  /etc also includes

--- a/deployments/jwebbinar/Dockerfile
+++ b/deployments/jwebbinar/Dockerfile
@@ -108,6 +108,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/    /opt/environments/
 
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_VERSION /opt
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_HASH /opt
+RUN  [ $USE_FROZEN -eq "1" ] && echo >/opt/FROZEN || echo >/opt/FLOATING
 
 # ----------------------------------------------------------------------
 # For standalone operation outside JupyterHub,  note that  /etc also includes

--- a/deployments/roman/Dockerfile
+++ b/deployments/roman/Dockerfile
@@ -95,6 +95,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/    /opt/environments/
 
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_VERSION /opt
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_HASH /opt
+RUN  [ $USE_FROZEN -eq "1" ] && echo >/opt/FROZEN || echo >/opt/FLOATING
 
 # ----------------------------------------------------------------------
 # For standalone operation outside JupyterHub,  note that  /etc also includes

--- a/deployments/tike/Dockerfile
+++ b/deployments/tike/Dockerfile
@@ -116,6 +116,7 @@ COPY --chown=${NB_UID}:${NB_GID} environments/    /opt/environments/
 
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_VERSION /opt
 COPY --chown=${NB_UID}:${NB_GID}  MISSION_HASH /opt
+RUN  [ $USE_FROZEN -eq "1" ] && echo >/opt/FROZEN || echo >/opt/FLOATING
 
 # ----------------------------------------------------------------------
 # For standalone operation outside JupyterHub,  note that  /etc also includes

--- a/scripts/image-freeze
+++ b/scripts/image-freeze
@@ -10,4 +10,4 @@ cd $IMAGE_DIR
 
 rm -rf env-frozen
 image-cp /opt/env-frozen
-
+release-hashes

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,80 @@
+#! /bin/bash
+
+if [ $# -lt 2 ]; then
+    usage: "`basename $0`  <common-version>  <mission-version>"
+    cat <<EOU
+<common-version> tags the generic code and relates this repo with
+the similarly tagged IAC repos currently in CodeCommit.  It is
+specified simply as semver,  e.g. 2.0.0
+
+<mission-version> tags a particular deployment with a build version
+unique to that mission.  the value input on the command line should
+be the simple numerical version which corresponds directly to a DMS
+release version (where applicable),  e.g. 16.0.0.  The value stored
+in the version file will include the mission/deployment-name,
+e.g. roman-16.0.0
+
+git hash updates:  this script also updates common and mission-specific
+hash files to their current values at the time of this commit.  Minus
+versions,  this enables trivial recall of exactly the code which was
+tagged here.
+
+Example command for initial build release:
+
+release 2.1.0  16.0.0
+
+EOU
+fi
+
+cd $JUPYTERHUB_DIR
+
+source ./setup-env
+
+COMMON_VER=$1
+MISSION_VER=${DEPLOYMENT_NAME}-$2
+
+git fetch upstream
+git checkout upstream/main
+git branch -D update-versions
+git checkout -b update-versions
+
+echo "Clearing any pending commit files."
+git reset HEAD
+
+echo "Updating release version for common and ${DEPLOYMENT_NAME}."
+
+echo $COMMON_VER  >deployments/common/VERSION
+echo $MISSION_VER  >deployments/${DEPLOYMENT_NAME}/MISSION_VERSION
+
+release-hashes
+
+echo "The repo status is:"
+git status
+echo "The version file update diffs are:"
+git diff
+echo
+echo "The next step will add, commit, and push the update-versions branch"
+echo "with only the 4 mission and common hash and version files."
+
+echo ======================================================================
+git add deployments/common/{HASH,VERSION} deployments/${DEPLOYMENT_NAME}/{MISSION_HASH,MISSION_VERSION}
+echo ======================================================================
+git status
+echo ======================================================================
+echo 
+
+read -p"If the above looks OK,  enter 'y' otherwise enter 'n' to abort:"  ans
+case $ans in
+    y|Y|yes|YES|Yes)
+	echo "Finalizing release update and push."
+	git commit -m "Updated versions to $COMMON_VER and $MISSION_VER"
+	echo ======================================================================
+	echo "Push the branch updated versions to GitHub and PR to spacetelescope/science-platform-versions@main"
+	echo "Review and merge the PR before proceeding to release-post-merge to finish tagging."
+	;;
+    *)
+	echo "Aborting release versions update."
+	git reset HEAD
+	git checkout -- deployments/common/{HASH,VERSION} deployments/${DEPLOYMENT_NAME}/{MISSION_HASH,MISSION_VERSION}
+	;;
+esac

--- a/scripts/release-hashes
+++ b/scripts/release-hashes
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+cd $JUPYTERHUB_DIR
+
+source ./setup-env
+echo "Updating saved git hashes for" `where`
+
+git rev-parse HEAD  >deployments/common/HASH
+
+git rev-parse HEAD  >deployments/${DEPLOYMENT_NAME}/MISSION_HASH

--- a/scripts/release-post-merge
+++ b/scripts/release-post-merge
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+git fetch upstream
+git checkout upstream/main
+read MISSION_VER  <deployments/${DEPLOYMENT_NAME}/MISSION_VERSION
+read COMMON_VER   <deployments/common/VERSION
+git tag ${MISSION_VER}-c-${COMMON_VER}
+git push --tags upstream


### PR DESCRIPTION
Adds scripts release, release-hashes, release-post-merge for doing formal build tagging.
Adds release-hashes to any image-freeze whether formal or not so that we can recover the exact checkout of the freeze.
Added /opt/FROZEN and /opt/FLOATING breadcrumb files to record the mode which was used
  to build an image since frozen requirements have no impact on frozen builds and strictly speaking
  formal releases should only be built from frozen requirements to max our chances of rebuilding it,
  or at least its environments,  later.